### PR TITLE
Eliminate exceptions being thrown inside CurrentDomain_FirstChanceException

### DIFF
--- a/Serilog.ExceptionalLogContext/ExceptionContextEnricher.cs
+++ b/Serilog.ExceptionalLogContext/ExceptionContextEnricher.cs
@@ -16,9 +16,9 @@ namespace Serilog.ExceptionalLogContext {
 
 		private void CurrentDomain_FirstChanceException(object sender, FirstChanceExceptionEventArgs exceptionEvent) {
 			try {
-				var context = LogContext.Clone();
 				if (!_exceptionToContextLookup.TryGetValue(exceptionEvent.Exception, out var _))
 				{
+					var context = LogContext.Clone();
 					// Call Add, not AddOrUpdate. If an exception is logged twice, the context from the original callsite will be preserved.
 					// This is desireable as subsequent throws/logs of the exception will unwind the stack, removing the context we're trying to preserve
 					// Note: this can throw, which absoutely necessitates the try/catch

--- a/Serilog.ExceptionalLogContext/ExceptionContextEnricher.cs
+++ b/Serilog.ExceptionalLogContext/ExceptionContextEnricher.cs
@@ -17,10 +17,13 @@ namespace Serilog.ExceptionalLogContext {
 		private void CurrentDomain_FirstChanceException(object sender, FirstChanceExceptionEventArgs exceptionEvent) {
 			try {
 				var context = LogContext.Clone();
-				// Call Add, not AddOrUpdate. If an exception is logged twice, the context from the original callsite will be preserved.
-				// This is desireable as subsequent throws/logs of the exception will unwind the stack, removing the context we're trying to preserve
-				// Note: this can throw, which absoutely necessitates the try/catch
-				_exceptionToContextLookup.Add(exceptionEvent.Exception, context);
+				if (!_exceptionToContextLookup.TryGetValue(exceptionEvent.Exception, out var _))
+				{
+					// Call Add, not AddOrUpdate. If an exception is logged twice, the context from the original callsite will be preserved.
+					// This is desireable as subsequent throws/logs of the exception will unwind the stack, removing the context we're trying to preserve
+					// Note: this can throw, which absoutely necessitates the try/catch
+					_exceptionToContextLookup.Add(exceptionEvent.Exception, context);
+				}
 			} catch {
 				// Any exceptions raised in here cannot be propagated, or the whole application will be taken down
 			}


### PR DESCRIPTION
This PR eliminates one source of exceptions being thrown inside CurrentDomain_FirstChanceException, by checking whether the context has already been attached.

One of my microservices started to deadlock after its load increased to the point that there were multiple exceptions happening simultaneously. I managed to reproduce the situation in a debugger, and the thread list showed hundreds to threads stuck in `_exceptionToContextLookup.Add()`.

I have not been able to find out why the threads were stuck there, but this PR fixes my problem and I figured it's a small and harmless fix that may benefit others as well.